### PR TITLE
bump kava-labs/go-sdk

### DIFF
--- a/executor/kava/executor.go
+++ b/executor/kava/executor.go
@@ -48,7 +48,6 @@ func NewExecutor(networkType client.ChainNetwork, cfg *util.KavaConfig) *Executo
 
 	// Set up Kava HTTP client and set codec
 	kavaClient := client.NewKavaClient(cdc, mnemonic, kava.Bip44CoinType, cfg.RpcAddr, networkType)
-	kavaClient.Keybase.SetCodec(cdc)
 
 	return &Executor{
 		Config:        cfg,

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/gorilla/mux v1.7.3
 	github.com/jinzhu/gorm v1.9.10
 	github.com/kava-labs/cosmos-sdk v0.38.3-stable.0.20200520223313-bfbe25d175da
-	github.com/kava-labs/go-sdk v0.1.2
+	github.com/kava-labs/go-sdk v0.1.5
 	github.com/kava-labs/tendermint v0.33.4-0.20200520221629-77480532c622
 	github.com/mattn/go-sqlite3 v1.11.0 // indirect
 	github.com/op/go-logging v0.0.0-20160315200505-970db520ece7

--- a/go.sum
+++ b/go.sum
@@ -375,6 +375,8 @@ github.com/kava-labs/cosmos-sdk v0.38.3-stable.0.20200520223313-bfbe25d175da h1:
 github.com/kava-labs/cosmos-sdk v0.38.3-stable.0.20200520223313-bfbe25d175da/go.mod h1:75qc1x7nKTGNQsu1GRL0TehEW9jrfQSGw4+ook4FdbE=
 github.com/kava-labs/go-sdk v0.1.2 h1:vYUAIgrMqyoTuvCv5D0MEqfgYgSounYE7XK8pE8XGF8=
 github.com/kava-labs/go-sdk v0.1.2/go.mod h1:+tjxGodAb7N9SiJwLYaZuy1ylD9x05f6U/UHVfkPUWQ=
+github.com/kava-labs/go-sdk v0.1.5 h1:7ztl0ETMJQjiRbMMiZ1dYoTaKdrQws6DEGeMrkLI7KM=
+github.com/kava-labs/go-sdk v0.1.5/go.mod h1:+tjxGodAb7N9SiJwLYaZuy1ylD9x05f6U/UHVfkPUWQ=
 github.com/kava-labs/iavl v0.13.4-0.20200520222038-6fa4fba8921e h1:MZZqo9oxf/c69fNje3K9Bd0rjBca76qmycYcnNphWzk=
 github.com/kava-labs/iavl v0.13.4-0.20200520222038-6fa4fba8921e/go.mod h1:MhuTGVny8uFF0Fe7sTbC8pj/5sncuSRBSOc1G2mrrJo=
 github.com/kava-labs/tendermint v0.33.4-0.20200520221629-77480532c622 h1:uqsJITDXMP5Lm4ZHhDWP7QuI1XvoNn9zptTbp7/wrFg=


### PR DESCRIPTION
Bumps Kava's go-sdk to support changes in https://github.com/binance-chain/bep3-deputy/pull/4.